### PR TITLE
Fix case of oauth_authorize path

### DIFF
--- a/src/JonnyW/MagentoOAuth/OAuth1/Service/Magento.php
+++ b/src/JonnyW/MagentoOAuth/OAuth1/Service/Magento.php
@@ -24,7 +24,7 @@ class Magento extends AbstractService
     const REQUEST_TOKEN_ENDPOINT             = '/oauth/initiate';
     const ACCESS_TOKEN_ENDPOINT              = '/oauth/token';
     const AUTHORIZATION_ENDPOINT_CUSTOMER    = '/oauth/authorize';
-    const AUTHORIZATION_ENDPOINT_ADMIN       = '/admin/oAuth_authorize';
+    const AUTHORIZATION_ENDPOINT_ADMIN       = '/admin/oauth_authorize';
 
     /**
      * Authorization endpoint

--- a/tests/JonnyW/MagentoOAuth/Unit/OAuth1/Service/MagentoTest.php
+++ b/tests/JonnyW/MagentoOAuth/Unit/OAuth1/Service/MagentoTest.php
@@ -184,7 +184,7 @@ class MagentoTest extends \PHPUnit_Framework_TestCase
 
         $uri->expects($this->once())
             ->method('setPath')
-            ->with($this->identicalTo('/admin/oAuth_authorize'));
+            ->with($this->identicalTo('/admin/oauth_authorize'));
 
         $magento->getAuthorizationEndpoint();
     }


### PR DESCRIPTION
The path should be in lower case.  Some systems will let you get away with the capital A, but others won't.
